### PR TITLE
Update tools docker-compose.yml for sf4

### DIFF
--- a/makerspacelt/tools/docker-compose.yml
+++ b/makerspacelt/tools/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     volumes:
       - './src:/home/project/src'
     environment:
-      APACHE_DOCUMENTROOT: /home/project/src/web
+      APACHE_DOCUMENTROOT: /home/project/src/public
       NFQ_PROJECT_ROOT: /home/project/src
       NFQ_ENABLE_APACHE_MODULES: rewrite
 


### PR DESCRIPTION
The 'web' directory has changed in symfony 4 to 'public'. Update docker-compose.yml to support that.